### PR TITLE
Fix error handling in account routes

### DIFF
--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -37,7 +37,7 @@ router.get("/", (_, res) => {
       delete json.nextId; // deletar campo de proximo id
       res.send(json);
     } catch (error) {
-      res.status(400).send({ error: err.message });
+      res.status(400).send({ error: error.message });
     }
   });
 });
@@ -57,7 +57,7 @@ router.get("/:id", (req, res) => {
         res.send();
       }
     } catch (error) {
-      res.status(400).send({ error: err.message });
+      res.status(400).send({ error: error.message });
     }
   });
 });
@@ -72,13 +72,13 @@ router.delete("/:id", (req, res) => {
 
       fs.writeFile(global.fileName, JSON.stringify(json), err => {
         if (err) {
-          res.send.status(400).send({ error: err.message });
+          res.status(400).send({ error: err.message });
         } else {
           res.send("Registro excluído com sucesso!");
         }
       });
     } catch (error) {
-      res.status(400).send({ error: err.message });
+      res.status(400).send({ error: error.message });
     }
   });
 });
@@ -97,13 +97,13 @@ router.put("/", (req, res) => {
 
       fs.writeFile(global.fileName, JSON.stringify(json), err => {
         if (err) {
-          res.send.status(400).send({ error: err.message });
+          res.status(400).send({ error: err.message });
         } else {
           res.send();
         }
       });
     } catch (error) {
-      res.status(400).send({ error: err.message });
+      res.status(400).send({ error: error.message });
     }
   });
 });
@@ -127,7 +127,7 @@ router.post('/transaction', (req, res) => {
 
       fs.writeFile(global.fileName, JSON.stringify(json), err => {
         if (err) {
-          res.send.status(400).send({ error: err.message });
+          res.status(400).send({ error: err.message });
         } else {
           res.send(json.accounts[index]);
         }


### PR DESCRIPTION
## Summary
- fix wrong order for `send` and `status`
- use the correct variable in error handlers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68459d7e8af88327a289bd4abfdf64db