### PR TITLE
Add jest and initial test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # my_bank_api
 Repositório onde treino a criação de uma api de banco
+
+## Como rodar os testes
+
+Execute:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const accountsRouter = require('../routes/accounts');
+
+describe('POST /account', () => {
+  let app;
+  const testFile = path.join(__dirname, 'accounts-test.json');
+
+  beforeEach(() => {
+    fs.writeFileSync(testFile, JSON.stringify({ nextId: 1, accounts: [] }));
+    global.fileName = testFile;
+    app = express();
+    app.use(express.json());
+    app.use('/account', accountsRouter);
+  });
+
+  afterEach(() => {
+    fs.unlinkSync(testFile);
+  });
+
+  it('should create account and return created object', async () => {
+    const newAccount = { name: 'Test User', balance: 100 };
+    const res = await request(app).post('/account').send(newAccount);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: 1, ...newAccount });
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest and Supertest as dev dependencies
- add first API test covering `POST /account`
- document how to run the test suite

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459d889e448327ba1efa4174767a17